### PR TITLE
Add shorthand multi-f invocation for depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ f ts 2
 f py --no-copy
 ```
 
+### Shorthand Depth with Repeated `f`
+
+Link the script under multiple `f` names to set a default search depth. The
+number of `f` characters in the command determines how many directory levels to
+scan:
+
+```bash
+# One level deep (equivalent to `f 1`)
+f
+
+# Two levels deep
+ff
+
+# Three levels deep
+fff
+```
+
+Create symlinks for the variants you need:
+
+```bash
+ln -s /usr/local/bin/f /usr/local/bin/ff
+ln -s /usr/local/bin/f /usr/local/bin/fff
+```
+
 ### File Type Shortcuts
 
 The script includes built-in shortcuts for common file types:

--- a/f
+++ b/f
@@ -127,6 +127,13 @@ for arg in "$@"; do
   fi
 done
 
+# Infer default depth from command name if none provided
+script_name=$(basename "$0")
+if [[ $script_name =~ ^f+$ ]] && [ -z "$max_depth" ]; then
+  max_depth=${#script_name}
+  depth="-maxdepth $max_depth"
+fi
+
 # Get current directory name
 DIR_NAME=$(basename "$(pwd)")
 


### PR DESCRIPTION
## Summary
- infer default search depth from repeated `f` characters in the invoked command name
- document linking the script under names like `ff` or `fff` to set default depth

## Testing
- `bash -n f`
- `bash f --no-copy --no-tree`
- `ln -s f ff && bash ff --no-copy --no-tree && rm ff`


------
https://chatgpt.com/codex/tasks/task_e_68936fe8f884832696d612eb3da9b591